### PR TITLE
Live tracking

### DIFF
--- a/PUBGSharp/Net/Model/LiveTrackingStat.cs
+++ b/PUBGSharp/Net/Model/LiveTrackingStat.cs
@@ -14,6 +14,8 @@ namespace PUBGSharp.Net.Model
         [JsonConverter(typeof(StringEnumConverter))]
         public Region Region { get; set; }
 
+        public int Season { get; set; }
+
         public DateTime Date { get; set; }
 
         public double Delta { get; set; }

--- a/PUBGSharp/Net/Model/LiveTrackingStat.cs
+++ b/PUBGSharp/Net/Model/LiveTrackingStat.cs
@@ -1,0 +1,14 @@
+﻿namespace PUBGSharp.Net.Model
+{
+    public class LiveTrackingStat
+    {
+        public int Match { get; set; }
+        public string MatchDisplay { get; set; }
+        public int RegionId { get; set; }
+        public string Region { get; set; }
+        public string Date { get; set; }
+        public double Delta { get; set; }
+        public double Value { get; set; }
+        public string message { get; set; }
+    }
+}

--- a/PUBGSharp/Net/Model/LiveTrackingStat.cs
+++ b/PUBGSharp/Net/Model/LiveTrackingStat.cs
@@ -1,14 +1,25 @@
-﻿namespace PUBGSharp.Net.Model
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using PUBGSharp.Data;
+using System;
+
+namespace PUBGSharp.Net.Model
 {
     public class LiveTrackingStat
     {
-        public int Match { get; set; }
-        public string MatchDisplay { get; set; }
-        public int RegionId { get; set; }
-        public string Region { get; set; }
-        public string Date { get; set; }
+        [JsonProperty("MatchDisplay")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public Mode Mode { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public Region Region { get; set; }
+
+        public DateTime Date { get; set; }
+
         public double Delta { get; set; }
+
         public double Value { get; set; }
-        public string message { get; set; }
+
+        public string Message { get; set; }
     }
 }

--- a/PUBGSharp/Net/Model/StatsResponse.cs
+++ b/PUBGSharp/Net/Model/StatsResponse.cs
@@ -11,5 +11,6 @@ namespace PUBGSharp.Net.Model
         public string PlayerName { get; set; }
         public int PubgTrackerId { get; set; }
         public List<StatsRoot> Stats { get; set; }
+        public List<LiveTrackingStat> LiveTracking { get; set; }
     }
 }


### PR DESCRIPTION
PUBGTracker api returns a collection of the last 10 "changes" in stats, and adds a message if appropriate(new high rank, etc).

Each collection element looks like this:
`{
      "Match": 3,
      "MatchDisplay": "Squad",
      "Season": 2,
      "RegionId": 4,
      "Region": "oc",
      "Date": "2017-07-16T11:45:48.933",
      "Delta": 2.4909999999999854,
      "Value": 1840.197,
      "message": "Climbed to Rank #8,492 in oc!"
    }`

Unfortunately the Match and Season values returned by the api look to be indexed from 1, and hence dont match up with the existing enums in PUBGSharp.
Fortunately they also provide the MatchDisplay which we can use, but the only clean solutions for Season is to either leave it as is, or adjust PUBGSharps enums(which isn't great obviously, as it would break things for people who have stored the previous enums somewhere).