### PR TITLE
Added ConfigureAwait(false) to library awaits.

### DIFF
--- a/PUBGSharp.Examples/Program.cs
+++ b/PUBGSharp.Examples/Program.cs
@@ -20,7 +20,7 @@ namespace PUBGSharp.Examples
             // dispose the PUBGStatsClient manually with the Dispose method.
             using (var statsClient = new PUBGStatsClient("api-key-here"))
             {
-                var stats = await statsClient.GetPlayerStatsAsync("Mithrain");
+                var stats = await statsClient.GetPlayerStatsAsync("Mithrain").ConfigureAwait(false);
 
                 // Print out player name and date the stats were last updated at.
                 Console.WriteLine($"{stats.PlayerName}, last updated at: {stats.LastUpdated}");

--- a/PUBGSharp.Test/PUBGStatsClientTests.cs
+++ b/PUBGSharp.Test/PUBGStatsClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PUBGSharp.Net.Model;
 
@@ -18,21 +19,13 @@ namespace PUBGSharp.Test
         }
 
         [TestMethod]
-        public void GetPlayerStatsAsync_ShouldRaiseArgumentException_WhenNoPlayerNameProvided()
+        [ExpectedException(typeof(ArgumentException))]
+        public async Task GetPlayerStatsAsync_ShouldRaiseArgumentException_WhenNoPlayerNameProvided()
         {
             //Arrange
             var client = new PUBGStatsClient("dummy");
             //Act
-            try
-            {
-                StatsResponse responseTask = client.GetPlayerStatsAsync(null).Result;
-            }
-            catch (Exception e)
-            {
-                //Assert
-                //In case of awaitable tasks, aggregate exception is thrown, which should contain expected ArgumentException.
-                Assert.IsInstanceOfType(e.InnerException, typeof(ArgumentException));
-            }
+            StatsResponse responseTask = await client.GetPlayerStatsAsync(null).ConfigureAwait(false);
         }
     }
 }

--- a/PUBGSharp/Net/HttpRequester.cs
+++ b/PUBGSharp/Net/HttpRequester.cs
@@ -22,13 +22,13 @@ namespace PUBGSharp.Net
         {
             try
             {
-                using (var response = await _client.GetAsync($"https://pubgtracker.com/api/profile/pc/{playerName}?region={region.ToString().ToLower()}"))
+                using (var response = await _client.GetAsync($"https://pubgtracker.com/api/profile/pc/{playerName}?region={region.ToString().ToLower()}").ConfigureAwait(false))
                 {
                     if (!response.IsSuccessStatusCode)
                     {
                         throw new PUBGSharpException($"Could not retrieve stats, status code: {response.StatusCode}.");
                     }
-                    var responseData = await response.Content.ReadAsStringAsync();
+                    var responseData = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     var result = JsonConvert.DeserializeObject<StatsResponse>(responseData);
                     if (result.AccountId == null)
                     {

--- a/PUBGSharp/Net/HttpRequesterThrottle.cs
+++ b/PUBGSharp/Net/HttpRequesterThrottle.cs
@@ -27,7 +27,7 @@ namespace PUBGSharp.Net
                 {
                     await Task.Delay(TimeSpan.FromSeconds(1) - TimeSpan.FromMilliseconds(diff.TotalMilliseconds));
                 }
-                var response = await base.RequestAsync(playerName, region);
+                var response = await base.RequestAsync(playerName, region).ConfigureAwait(false);
                 _lastRequest = DateTime.UtcNow;
                 return response;
             }

--- a/PUBGSharp/PUBGStatsClient.cs
+++ b/PUBGSharp/PUBGStatsClient.cs
@@ -33,7 +33,7 @@ namespace PUBGSharp
             {
                 throw new ArgumentException("Player name cannot be empty.");
             }
-            return await _httpRequester.RequestAsync(playerName, region);
+            return await _httpRequester.RequestAsync(playerName, region).ConfigureAwait(false);
         }
 
         public void Dispose()


### PR DESCRIPTION
- Updated async awaits to ConfigureAwait(false) because we don't need to resume on a specific context as a library. Eeks out a little more performance as we're not telling the awaiter to capture the current context.
- Updated Test method to use async to clean up the assertion.

Stephen Cleary has a good blog out there on this for reference: http://blog.stephencleary.com/2012/02/async-and-await.html.